### PR TITLE
STR-122: add dependency normalizer with script, docs and tests

### DIFF
--- a/core/imports/dependency-normalizer.ts
+++ b/core/imports/dependency-normalizer.ts
@@ -1,0 +1,121 @@
+/**
+ * Normalize a resolver snapshot into a canonical dependency graph representation.
+ * - Nodes: unique files (importers and successfully resolved targets), sorted alphabetically.
+ * - Edges: one per successful import (from importer to resolvedPath), deduplicated and sorted.
+ * - Unresolved: original order of failed resolutions with importer/specifier/reason.
+ */
+
+export type ResolverSnapshot = {
+  summary: {
+    generatedAt: string;
+    [key: string]: unknown;
+  };
+  entries: Array<{
+    importer: string;
+    specifier: string;
+    resolution: {
+      ok: boolean;
+      resolvedPath?: string;
+      reason?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  }>;
+};
+
+export type NormalizedNode = { id: string; type: 'file' };
+export type NormalizedEdge = { from: string; to: string; kind: 'import' };
+export type NormalizedUnresolved = { importer: string; specifier: string; reason: string };
+
+export type NormalizedGraph = {
+  version: string;
+  nodes: NormalizedNode[];
+  edges: NormalizedEdge[];
+  unresolved: NormalizedUnresolved[];
+};
+
+export function normalizeResolvedImports(snapshot: ResolverSnapshot): NormalizedGraph {
+  validateSnapshot(snapshot);
+
+  // Extract graph components in deterministic order so output is stable across runs.
+  const nodes = collectNodes(snapshot.entries);
+  const edges = collectEdges(snapshot.entries);
+  const unresolved = collectUnresolved(snapshot.entries);
+
+  return {
+    version: snapshot.summary.generatedAt,
+    nodes,
+    edges,
+    unresolved,
+  };
+}
+
+function validateSnapshot(snapshot: ResolverSnapshot) {
+  if (!snapshot || typeof snapshot !== 'object') {
+    throw new Error('Invalid snapshot: expected object');
+  }
+  if (!snapshot.summary || typeof snapshot.summary.generatedAt !== 'string') {
+    throw new Error('Invalid snapshot: summary.generatedAt is required');
+  }
+  if (!Array.isArray(snapshot.entries)) {
+    throw new Error('Invalid snapshot: entries must be an array');
+  }
+}
+
+function collectNodes(entries: ResolverSnapshot['entries']): NormalizedNode[] {
+  const nodeIds = new Set<string>();
+
+  // Capture all importers plus all successfully resolved targets.
+  // This ensures the node list is a superset of every endpoint seen in the snapshot.
+  for (const entry of entries) {
+    if (entry.importer) {
+      nodeIds.add(entry.importer);
+    }
+    if (entry.resolution?.ok && entry.resolution.resolvedPath) {
+      nodeIds.add(entry.resolution.resolvedPath);
+    }
+  }
+
+  return Array.from(nodeIds)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    .map((id) => ({ id, type: 'file' as const }));
+}
+
+function collectEdges(entries: ResolverSnapshot['entries']): NormalizedEdge[] {
+  const seen = new Set<string>();
+  const edges: NormalizedEdge[] = [];
+
+  // One edge per successful import, deduplicated by from->to to avoid duplicates
+  // when multiple identical imports appear across lines or files.
+  for (const entry of entries) {
+    const resolvedPath = entry.resolution?.resolvedPath;
+    if (!entry.resolution?.ok || !resolvedPath) continue;
+
+    const key = `${entry.importer}->${resolvedPath}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ from: entry.importer, to: resolvedPath, kind: 'import' });
+  }
+
+  return edges.sort((a, b) => {
+    if (a.from === b.from) return a.to < b.to ? -1 : a.to > b.to ? 1 : 0;
+    return a.from < b.from ? -1 : 1;
+  });
+}
+
+function collectUnresolved(entries: ResolverSnapshot['entries']): NormalizedUnresolved[] {
+  const unresolved: NormalizedUnresolved[] = [];
+
+  // Preserve original order for unresolved entries for easier debugging.
+  // Each item captures minimal context: who imported, what specifier, and why it failed.
+  for (const entry of entries) {
+    if (entry.resolution?.ok) continue;
+    unresolved.push({
+      importer: entry.importer,
+      specifier: entry.specifier,
+      reason: entry.resolution?.reason ?? 'UNKNOWN',
+    });
+  }
+
+  return unresolved;
+}

--- a/docs/docs/graph-system/dependency-graph-normalizer.md
+++ b/docs/docs/graph-system/dependency-graph-normalizer.md
@@ -1,0 +1,110 @@
+---
+title: Dependency Graph Normalizer
+sidebar_position: 4
+description: Converts resolver snapshots into a canonical dependency graph for Structura’s analyses and Feature Flow.
+---
+
+## Purpose
+- Converts a resolver snapshot into a canonical dependency graph.
+- Feeds later analyses, UI features, and the Feature Flow engine with a clean, deterministic representation.
+
+## Input Format (Resolver Snapshot)
+```json
+{
+  "summary": {
+    "generatedAt": "2025-12-10T23:21:09.876Z"
+  },
+  "entries": [
+    {
+      "importer": "path/to/file.js",
+      "specifier": "./module",
+      "resolution": {
+        "ok": true,
+        "resolvedPath": "path/to/module.js",
+        "reason": "FILE_NOT_FOUND"
+      }
+    }
+  ]
+}
+```
+- `importer`: Absolute path of the file declaring the import.
+- `specifier`: The raw module specifier string.
+- `resolution.ok`: `true` if the specifier was resolved; `false` otherwise.
+- `resolution.resolvedPath`: Absolute path of the resolved target (present when `ok` is `true`).
+- `resolution.reason`: Failure reason (present when `ok` is `false`).
+
+## Output Format (Normalized Graph)
+```json
+{
+  "version": "2025-12-10T23:21:09.876Z",
+  "nodes": [{ "id": "...", "type": "file" }],
+  "edges": [{ "from": "...", "to": "...", "kind": "import" }],
+  "unresolved": [{ "importer": "...", "specifier": "...", "reason": "..." }]
+}
+```
+- `Node = { id: string, type: "file" }`
+- `Edge = { from: string, to: string, kind: "import" }`
+- `UnresolvedEntry = { importer: string, specifier: string, reason: string }`
+
+## Node Generation Rules
+- Include every `importer`.
+- Include every `resolvedPath` when `resolution.ok` is `true`.
+- Include nodes even if no edges reference them (complete project view and dead-file detection).
+- Deduplicate by `id`.
+- Sort alphabetically.
+- All nodes use `{ id, type: "file" }`.
+
+## Edge Generation Rules
+- Only include entries where `resolution.ok` is `true`.
+- Shape: `{ from: importer, to: resolvedPath, kind: "import" }`.
+- Deduplicate edges (by `from` + `to`).
+- Sort alphabetically by `from`, then by `to`.
+- Unresolved imports are not added as edges.
+- Resulting edges are ready for graph storage (e.g., Neo4j) and Feature Flow.
+
+## Unresolved Import Rules
+- Capture every failed resolution as `{ importer, specifier, reason }`.
+- Preserve the original order from the snapshot.
+- Excluded from the graph itself to keep edges clean.
+
+## Versioning
+- `version` is set to `summary.generatedAt` from the resolver snapshot.
+- Keeps all downstream stages aligned with the snapshot version.
+
+## Stability and Determinism
+- Sorting nodes and edges guarantees deterministic output across runs.
+- Deduplication removes duplicate signals, yielding a clean graph.
+- Determinism supports stable snapshots and repeatable analyses.
+
+## Example Output (Minimal)
+```json
+{
+  "version": "2025-01-01T00:00:00.000Z",
+  "nodes": [
+    { "id": "/app/src/index.js", "type": "file" },
+    { "id": "/app/src/lib/util.js", "type": "file" }
+  ],
+  "edges": [
+    { "from": "/app/src/index.js", "to": "/app/src/lib/util.js", "kind": "import" }
+  ],
+  "unresolved": [
+    { "importer": "/app/src/index.js", "specifier": "fs", "reason": "PACKAGE_NOT_FOUND" }
+  ]
+}
+```
+
+## Using the Normalization Script
+- Script: `scripts/normalizeResolvedImports.ts`
+- Usage:
+  ```bash
+  npx ts-node scripts/normalizeResolvedImports.ts <resolved-imports.json> [--out output.json]
+  ```
+- Behavior:
+  - Reads a resolver snapshot JSON.
+  - Produces `normalized-graph.json` in the same directory by default (or `--out` target).
+  - Logs summary counts (version, nodes, edges, unresolved).
+
+## Summary
+- Produces a clean, complete dependency graph and unresolved list from resolver snapshots.
+- Deterministic: sorted and deduplicated nodes/edges.
+- Ready for storage, graph queries, and Feature Flow consumption.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -69,6 +69,7 @@ const sidebars: SidebarsConfig = {
             'graph-system/dependency-graph-model',
             'graph-system/import-extractor',
             'graph-system/import-resolver',
+            'graph-system/dependency-graph-normalizer',
           ],
         },
         {

--- a/output/resolve-imports/normalized-graph.json
+++ b/output/resolve-imports/normalized-graph.json
@@ -1,0 +1,2676 @@
+{
+  "version": "2025-12-10T23:21:09.876Z",
+  "nodes": [
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/actions/notify_published.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/api.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/check-build-version.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/helpers/parser.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/resolveNPMTag.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/run-karma-tests.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/sponsors.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/bin/ssl_hotfix.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/examples/network_enhanced.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/gulpfile.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/cancel/CancelToken.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/cancel/isCancel.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/InterceptorManager.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/defaults/transitional.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/env/classes/FormData.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/env/data.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosTransformStream.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosURLSearchParams.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/HttpStatusCode.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/ZlibHeaderTransformStream.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/bind.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/callbackify.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/combineURLs.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/estimateDataURLDecodedBytes.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToJSON.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/isAbsoluteURL.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/isAxiosError.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/isURLSameOrigin.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/parseHeaders.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/parseProtocol.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/readBlob.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/speedometer.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/spread.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/throttle.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/toURLEncodedForm.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/trackStream.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/helpers/validator.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/Blob.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/FormData.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/URLSearchParams.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/browser/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/common/utils.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/FormData.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/URLSearchParams.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/platform/node/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-alias/dist/es/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-babel/dist/index.es.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-commonjs/dist/index.es.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-json/dist/index.es.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-node-resolve/dist/es/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/abortcontroller-polyfill/dist/cjs-ponyfill.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/body-parser/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/chalk/source/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/dev-null/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/events/events.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/express/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/follow-redirects/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/form-data/lib/form_data.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/formdata-node/lib/browser.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/formidable/src/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/fs-extra/lib/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/get-stream/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/gulp/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/handlebars/lib/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/memoizee/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/minimist/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/multer/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/pacote/lib/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/pretty-bytes/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/proxy-from-env/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-auto-external/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-bundle-size/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-terser/rollup-plugin-terser.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/selfsigned/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/stream-throttle/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/string-replace-async/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/tar-stream/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/package.json",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/sandbox/client.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/sandbox/server.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/helpers/retry.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/cjs/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/esm/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts-require-default/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts-require-default/index.ts",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.ts",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/module/ts/index.ts",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/__helpers.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/basicAuth.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/cancel.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/cancel/CancelToken.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/cancel/CanceledError.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/cancel/isCancel.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/core/AxiosError.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/core/buildFullPath.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/core/mergeConfig.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/core/settle.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/core/transformData.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/defaults.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/formdata.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/bind.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/buildURL.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/combineURLs.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/cookies.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/formDataToJSON.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/isAbsoluteURL.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/isAxiosError.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/isURLSameOrigin.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/parseHeaders.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/spread.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/toFormData.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/helpers/validator.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/transform.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/endsWith.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/extend.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/forEach.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/isX.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/kindOf.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/kindOfTest.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/merge.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/toArray.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/toFlatObject.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/utils/trim.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/specs/xsrf.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/adapters/adapters.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/core/Axios.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/core/AxiosHeaders.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/defaults/transformResponse.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/helpers/composeSignals.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/helpers/estimateDataURLDecodedBytes.spec.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/helpers/fromDataURI.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/helpers/parseProtocol.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/platform/index.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-1038255.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-7361793.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/regression/bugs.js",
+      "type": "file"
+    },
+    {
+      "id": "/Users/rabyatayal/dev/axios/test/unit/utils/utils.js",
+      "type": "file"
+    }
+  ],
+  "edges": [
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/parser.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/memoizee/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/api.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/handlebars/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/actions/notify_published.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/actions/notify_published.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/minimist/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/api.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/check-build-version.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/check-build-version.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/handlebars/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/chalk/source/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/string-replace-async/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/handlebars/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/pacote/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/pretty-bytes/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/tar-stream/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/resolveNPMTag.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/resolveNPMTag.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/run-karma-tests.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/chalk/source/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/run-karma-tests.js",
+      "to": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/sponsors.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/helpers/colorize.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/sponsors.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/bin/sponsors.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/minimist/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/gulpfile.js",
+      "to": "/Users/rabyatayal/dev/axios/bin/githubAxios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/gulpfile.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/fs-extra/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/gulpfile.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/gulp/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/gulpfile.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/minimist/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/trackStream.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/transitional.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/env/data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosTransformStream.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/ZlibHeaderTransformStream.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/callbackify.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/estimateDataURLDecodedBytes.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/readBlob.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/events/events.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/follow-redirects/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/proxy-from-env/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/transitional.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/parseProtocol.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/adapters/xhr.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CancelToken.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/isCancel.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/env/data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/HttpStatusCode.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/bind.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToJSON.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isAxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/spread.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/cancel/CancelToken.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/InterceptorManager.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/validator.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/parseHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/InterceptorManager.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/combineURLs.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isAbsoluteURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/isCancel.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/dispatchRequest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/transitional.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToJSON.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toURLEncodedForm.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/env/classes/FormData.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/form-data/lib/form_data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosTransformStream.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosURLSearchParams.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosURLSearchParams.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/callbackify.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToJSON.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/readBlob.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/parseProtocol.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/isAxiosError.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/isURLSameOrigin.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/parseHeaders.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/speedometer.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/throttle.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/progressEventReducer.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isURLSameOrigin.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/resolveConfig.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/FormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toURLEncodedForm.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toURLEncodedForm.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/toURLEncodedForm.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/validator.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/helpers/validator.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/env/data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/URLSearchParams.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosURLSearchParams.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/browser/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/Blob.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/browser/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/FormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/browser/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/browser/classes/URLSearchParams.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/common/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/node/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/FormData.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/form-data/lib/form_data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/URLSearchParams.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/node/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/FormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/platform/node/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/node/classes/URLSearchParams.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/bind.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-alias/dist/es/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-babel/dist/index.es.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-commonjs/dist/index.es.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-json/dist/index.es.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/@rollup/plugin-node-resolve/dist/es/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-auto-external/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-bundle-size/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/rollup-plugin-terser/rollup-plugin-terser.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "to": "/Users/rabyatayal/dev/axios/package.json",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/sandbox/client.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/sandbox/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/formidable/src/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/get-stream/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/selfsigned/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/stream-throttle/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/cjs/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/esm/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/axios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/fs-extra/lib/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts-require-default/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts-require-default/index.ts",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.ts",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/module/ts/index.ts",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/__helpers.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/basicAuth.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/abortcontroller-polyfill/dist/cjs-ponyfill.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel/CancelToken.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CancelToken.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel/CancelToken.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel/CanceledError.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel/isCancel.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/CanceledError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/cancel/isCancel.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/cancel/isCancel.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/AxiosError.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/buildFullPath.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/buildFullPath.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/mergeConfig.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/mergeConfig.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/mergeConfig.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/mergeConfig.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/settle.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/settle.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/core/transformData.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/defaults.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/defaults.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/formdata.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/test/helpers/retry.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/bind.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/bind.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/buildURL.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/buildURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/combineURLs.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/combineURLs.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/cookies.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/formDataToJSON.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToJSON.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/isAbsoluteURL.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isAbsoluteURL.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/isAxiosError.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/isAxiosError.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isAxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/isURLSameOrigin.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/isURLSameOrigin.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/parseHeaders.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/parseHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/spread.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/spread.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/toFormData.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/toFormData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/helpers/validator.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/validator.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/transform.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/endsWith.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/extend.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/forEach.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/isX.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/kindOf.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/kindOfTest.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/merge.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/toArray.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/toFlatObject.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/utils/trim.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/specs/xsrf.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/cookies.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/adapters.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/adapters.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/abortcontroller-polyfill/dist/cjs-ponyfill.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "to": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosError.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/abortcontroller-polyfill/dist/cjs-ponyfill.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/body-parser/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/dev-null/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/express/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/form-data/lib/form_data.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/formdata-node/lib/browser.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/formidable/src/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/get-stream/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/multer/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/url/url.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/util/util.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "to": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/Axios.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/core/Axios.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/core/AxiosHeaders.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/AxiosHeaders.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/core/AxiosHeaders.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/defaults/transformResponse.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/core/transformData.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/defaults/transformResponse.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/defaults/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/defaults/transformResponse.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/composeSignals.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/composeSignals.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/composeSignals.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/estimateDataURLDecodedBytes.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/estimateDataURLDecodedBytes.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/estimateDataURLDecodedBytes.spec.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/fromDataURI.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/fromDataURI.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/fromDataURI.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/parseProtocol.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/helpers/parseProtocol.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/parseProtocol.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/helpers/parseProtocol.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/platform/index.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/platform/index.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-1038255.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-1038255.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-7361793.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-7361793.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/platform/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-7361793.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/bugs.js",
+      "to": "/Users/rabyatayal/dev/axios/index.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/regression/bugs.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/utils/utils.js",
+      "to": "/Users/rabyatayal/dev/axios/lib/utils.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/utils/utils.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/assert/assert.js",
+      "kind": "import"
+    },
+    {
+      "from": "/Users/rabyatayal/dev/axios/test/unit/utils/utils.js",
+      "to": "/Users/rabyatayal/dev/axios/node_modules/form-data/lib/form_data.js",
+      "kind": "import"
+    }
+  ],
+  "unresolved": [
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/GithubAPI.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/RepoBot.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/actions/notify_published.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/check-build-version.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/check-build-version.js",
+      "specifier": "../dist/node/axios.cjs",
+      "reason": "FILE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/contributors.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/injectContributorsList.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "specifier": "zlib",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/pr.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/repo.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/resolveNPMTag.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/run-karma-tests.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/sponsors.js",
+      "specifier": "fs/promises",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/bin/ssl_hotfix.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/examples/network_enhanced.js",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/examples/server.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "specifier": "https",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "specifier": "http2",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "specifier": "zlib",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/adapters/http.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/helpers/AxiosTransformStream.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/helpers/ZlibHeaderTransformStream.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/helpers/formDataToStream.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/lib/platform/node/index.js",
+      "specifier": "crypto",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/rollup.config.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/sandbox/server.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/sandbox/server.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/sandbox/server.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "specifier": "http2",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/helpers/server.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/cjs/index.js",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/esm/index.js",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/esm/index.js",
+      "specifier": "axios/unsafe/core/settle.js",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/test.js",
+      "specifier": "child_process",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/ts/index.js",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/ts/index.ts",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.js",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/module/ts-require/index.ts",
+      "specifier": "axios",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "specifier": "https",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "specifier": "net",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/error-details.spec.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/fetch.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "https",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "net",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "zlib",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "fs",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "path",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/adapters/http.js",
+      "specifier": "dns",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-1038255.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/regression/SNYK-JS-AXIOS-7361793.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/regression/bugs.js",
+      "specifier": "http",
+      "reason": "PACKAGE_NOT_FOUND"
+    },
+    {
+      "importer": "/Users/rabyatayal/dev/axios/test/unit/utils/utils.js",
+      "specifier": "stream",
+      "reason": "PACKAGE_NOT_FOUND"
+    }
+  ]
+}

--- a/scripts/normalizeResolvedImports.ts
+++ b/scripts/normalizeResolvedImports.ts
@@ -1,0 +1,84 @@
+// Usage: npx ts-node scripts/normalizeResolvedImports.ts <resolved-imports.json> [--out output.json]
+// Example: npx ts-node scripts/normalizeResolvedImports.ts output/resolve-imports/resolved-imports.json --out output/resolve-imports/normalized-graph.json
+import fs from 'node:fs';
+import path from 'node:path';
+import { normalizeResolvedImports, ResolverSnapshot } from '../core/imports/dependency-normalizer';
+
+type CliArgs = {
+  input: string;
+  output: string;
+};
+
+function printUsage() {
+  console.log(`Normalize a resolved imports snapshot into a dependency graph.
+
+Usage:
+  npx ts-node scripts/normalizeResolvedImports.ts <resolved-imports.json> [--out output.json]
+
+Options:
+  --out/-o   Optional output path (default: <input dir>/normalized-graph.json)
+`);
+}
+
+function parseArgs(): CliArgs {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    process.exit(0);
+  }
+
+  let input = '';
+  let output = '';
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--out' || arg === '-o') {
+      output = args[++i];
+      continue;
+    }
+    if (arg.startsWith('--out=')) {
+      output = arg.split('=')[1];
+      continue;
+    }
+    if (!arg.startsWith('-') && !input) {
+      input = arg;
+      continue;
+    }
+    console.warn(`Ignoring unknown argument: ${arg}`);
+  }
+
+  if (!input) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const absInput = path.resolve(input);
+  const defaultOut = path.join(path.dirname(absInput), 'normalized-graph.json');
+  const absOutput = output ? path.resolve(output) : defaultOut;
+
+  return { input: absInput, output: absOutput };
+}
+
+function readSnapshot(filePath: string): ResolverSnapshot {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw) as ResolverSnapshot;
+}
+
+function main() {
+  const args = parseArgs();
+  if (!fs.existsSync(args.input)) {
+    console.error(`Input file not found: ${args.input}`);
+    process.exit(1);
+  }
+
+  const snapshot = readSnapshot(args.input);
+  const normalized = normalizeResolvedImports(snapshot);
+
+  fs.mkdirSync(path.dirname(args.output), { recursive: true });
+  fs.writeFileSync(args.output, JSON.stringify(normalized, null, 2), 'utf8');
+
+  console.log(`Normalized graph written to ${args.output}`);
+  console.log(`Version: ${normalized.version}, nodes: ${normalized.nodes.length}, edges: ${normalized.edges.length}, unresolved: ${normalized.unresolved.length}`);
+}
+
+main();

--- a/tests/imports/dependency-normalizer.test.ts
+++ b/tests/imports/dependency-normalizer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeResolvedImports } from '../../core/imports/dependency-normalizer';
+
+describe('normalizeResolvedImports', () => {
+  it('builds sorted, deduplicated nodes and edges while preserving unresolved order', () => {
+    const snapshot = {
+      summary: { generatedAt: '2025-01-01T00:00:00.000Z' },
+      entries: [
+        {
+          importer: '/proj/src/a.ts',
+          specifier: './b',
+          resolution: { ok: true, resolvedPath: '/proj/src/b.ts' },
+        },
+        {
+          importer: '/proj/src/a.ts',
+          specifier: './b-again',
+          resolution: { ok: true, resolvedPath: '/proj/src/b.ts' }, // duplicate edge, should be deduped
+        },
+        {
+          importer: '/proj/src/c.ts',
+          specifier: './a',
+          resolution: { ok: true, resolvedPath: '/proj/src/a.ts' },
+        },
+        {
+          importer: '/proj/src/d.ts',
+          specifier: './missing',
+          resolution: { ok: false, reason: 'FILE_NOT_FOUND' },
+        },
+        {
+          importer: '/proj/src/e.ts',
+          specifier: './unknown-reason',
+          resolution: { ok: false }, // should default reason to UNKNOWN
+        },
+      ],
+    };
+
+    const result = normalizeResolvedImports(snapshot);
+
+    expect(result.version).toBe('2025-01-01T00:00:00.000Z');
+    // Nodes include all importers plus all resolved targets, deduped and sorted.
+    expect(result.nodes).toEqual([
+      { id: '/proj/src/a.ts', type: 'file' },
+      { id: '/proj/src/b.ts', type: 'file' },
+      { id: '/proj/src/c.ts', type: 'file' },
+      { id: '/proj/src/d.ts', type: 'file' },
+      { id: '/proj/src/e.ts', type: 'file' },
+    ]);
+
+    // Edges deduped and sorted by from then to.
+    expect(result.edges).toEqual([
+      { from: '/proj/src/a.ts', to: '/proj/src/b.ts', kind: 'import' },
+      { from: '/proj/src/c.ts', to: '/proj/src/a.ts', kind: 'import' },
+    ]);
+
+    // Unresolved preserves order and reason handling.
+    expect(result.unresolved).toEqual([
+      { importer: '/proj/src/d.ts', specifier: './missing', reason: 'FILE_NOT_FOUND' },
+      { importer: '/proj/src/e.ts', specifier: './unknown-reason', reason: 'UNKNOWN' },
+    ]);
+  });
+
+  it('throws when snapshot is missing required fields', () => {
+    expect(() =>
+      normalizeResolvedImports({ summary: {}, entries: [] } as any)
+    ).toThrow(/generatedAt/);
+  });
+});


### PR DESCRIPTION
- Added dependency normalizer
- Introduced `normalizeResolvedImports.ts` script to convert resolved imports snapshot into a normalized dependency graph.
- Implemented CLI argument parsing for input and output file paths.
- Added functionality to read the snapshot, normalize the data, and write the output to a specified file.
- Created unit tests for `normalizeResolvedImports` to ensure correct behavior, including handling of duplicates and unresolved imports.