### PR TITLE
STR-126: Implement normalization functions for AST nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,13 @@ npm run preview --workspace frontend
 - Run format checks before pushing: `npm run format:check`.
 - Keep environment examples up to date when adding new env vars.
 
+### Snapshot Versioning and Semantic Changes
+
+- `SNAPSHOT_VERSION` is a manually managed constant (see `core/config/snapshotVersion.ts` and docs/ast-system/snapshot-versioning.md).
+- Bump the snapshot version when you change AST normalization semantics, node identity inputs, extraction rules, or graph construction semantics.
+- Do **not** bump for refactors, performance tweaks, formatting, or logging-only changes.
+- Skipping required bumps can corrupt persisted analysis, break graph comparisons, and invalidate evolution analysis results.
+
 ## License
 
 All rights reserved.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,7 +15,7 @@ model User {
 
 
 model AstNode {
-  id            String   @id @default(uuid()) @db.Uuid
+  id            String   @id @db.Uuid
   filePath      String
   type          String
 

--- a/core/config/snapshotVersion.ts
+++ b/core/config/snapshotVersion.ts
@@ -1,0 +1,5 @@
+// Global snapshot version for AST normalization and analysis.
+// Bump when normalized AST schema or extraction semantics change and ids should intentionally
+// shift. Keep stable across runs otherwise. See docs/ast-system/snapshot-versioning.md and
+// README.md ("Snapshot Versioning and Semantic Changes") for guidance.
+export const SNAPSHOT_VERSION = 'v1';

--- a/core/types/ast/base.ts
+++ b/core/types/ast/base.ts
@@ -12,6 +12,7 @@ import type { CallNode, BinaryOpNode, UnaryOpNode, MemberAccessNode } from './ex
 export interface BaseNode {
   id: string;
   type: string;
+  filePath: string;
   location?: {
     startLine: number;
     startCol: number;

--- a/core/utils/makeDeterministicId.ts
+++ b/core/utils/makeDeterministicId.ts
@@ -1,11 +1,17 @@
 import { createHash } from 'crypto';
 import { SyntaxNode } from 'tree-sitter';
 
-export function makeDeterministicId(node: SyntaxNode, filePath: string): string {
+export function makeDeterministicId(
+  node: SyntaxNode,
+  filePath: string,
+  snapshotVersion: string
+): string {
+  // snapshotVersion scopes identity to a specific analysis schema so changes can intentionally
+  // invalidate ids without altering the AST shape or node offsets.
   const start = node.startPosition;
   const end = node.endPosition;
 
-  const key = `${filePath}:${node.type}:${start.row}:${start.column}:${end.row}:${end.column}`;
+  const key = `${snapshotVersion}:${filePath}:${node.type}:${start.row}:${start.column}:${end.row}:${end.column}`;
 
   return createHash('sha256').update(key).digest('hex').slice(0, 16);
 }

--- a/core/utils/normalize.ts
+++ b/core/utils/normalize.ts
@@ -1,384 +1,60 @@
-import { SyntaxNode } from 'tree-sitter';
+import { SNAPSHOT_VERSION } from '../config/snapshotVersion';
+import { normalizeIdentifier, normalizeLiteral, normalizeCall } from './normalizers/expressions';
+import { normalizeFunction } from './normalizers/functions';
+import { normalizeImport } from './normalizers/imports';
+import { normalizeProgram } from './normalizers/program';
 import {
-  BaseNode,
-  BlockNode,
-  CallNode,
-  ConditionalNode,
-  ExpressionStatementNode,
-  FunctionNode,
-  IdentifierNode,
-  ImportNode,
-  LiteralNode,
-  LoopNode,
-  ModuleNode,
-  NormalizedNode,
-  ParameterNode,
-  ReturnNode,
-  VariableNode,
-  UnknownNode,
-} from '../types/ast';
-import { makeDeterministicId } from './makeDeterministicId';
+  normalizeConditional,
+  normalizeExpressionStatement,
+  normalizeLoop,
+  normalizeReturn,
+  normalizeVariableDeclaration,
+} from './normalizers/statements';
+import { normalizeUnknown } from './normalizers/unknown';
+import type { NormalizeFn } from './normalizers/common';
 
-export function normalize(node: SyntaxNode, source: string, filePath = ''): NormalizedNode {
+export const normalize: NormalizeFn = (
+  node,
+  source,
+  filePath = '',
+  snapshotVersion = SNAPSHOT_VERSION
+) => {
   switch (node.type) {
     case 'program':
-      return normalizeProgram(node, source, filePath);
+      return normalizeProgram(node, source, filePath, snapshotVersion, normalize);
     case 'parenthesized_expression':
-      return normalize(node.namedChildren[0] ?? node, source, filePath);
+      return normalize(node.namedChildren[0] ?? node, source, filePath, snapshotVersion);
     case 'identifier':
-      return normalizeIdentifier(node, source, filePath);
+      return normalizeIdentifier(node, source, filePath, snapshotVersion);
     case 'number':
     case 'string':
     case 'true':
     case 'false':
     case 'null':
-      return normalizeLiteral(node, source, filePath);
+      return normalizeLiteral(node, source, filePath, snapshotVersion);
     case 'call_expression':
-      return normalizeCall(node, source, filePath);
+      return normalizeCall(node, source, filePath, snapshotVersion, normalize);
     case 'function_declaration':
     case 'function':
     case 'arrow_function':
-      return normalizeFunction(node, source, filePath);
+      return normalizeFunction(node, source, filePath, snapshotVersion, normalize);
     case 'if_statement':
-      return normalizeConditional(node, source, filePath);
+      return normalizeConditional(node, source, filePath, snapshotVersion, normalize);
     case 'for_statement':
     case 'while_statement':
     case 'do_statement':
     case 'for_in_statement':
     case 'for_of_statement':
-      return normalizeLoop(node, source, filePath);
+      return normalizeLoop(node, source, filePath, snapshotVersion, normalize);
     case 'return_statement':
-      return normalizeReturn(node, source, filePath);
+      return normalizeReturn(node, source, filePath, snapshotVersion, normalize);
     case 'expression_statement':
-      return normalizeExpressionStatement(node, source, filePath);
+      return normalizeExpressionStatement(node, source, filePath, snapshotVersion, normalize);
     case 'lexical_declaration':
-      return normalizeVariableDeclaration(node, source, filePath);
+      return normalizeVariableDeclaration(node, source, filePath, snapshotVersion, normalize);
     case 'import_statement':
-      return normalizeImport(node, source, filePath);
+      return normalizeImport(node, source, filePath, snapshotVersion);
     default:
-      return normalizeUnknown(node, source, filePath);
+      return normalizeUnknown(node, source, filePath, snapshotVersion);
   }
-}
-
-function normalizeProgram(node: SyntaxNode, source: string, filePath: string): ModuleNode {
-  const body = node.namedChildren.map((child) => normalize(child, source, filePath));
-  return {
-    ...base(node, 'Module', filePath),
-    path: filePath,
-    body,
-  };
-}
-
-function normalizeIdentifier(node: SyntaxNode, _source: string, _filePath: string): IdentifierNode {
-  return {
-    ...base(node, 'Identifier', _filePath),
-    name: node.text,
-  };
-}
-
-function normalizeLiteral(node: SyntaxNode, _source: string, _filePath: string): LiteralNode {
-  let literalType: LiteralNode['literalType'] = 'null';
-  let value: LiteralNode['value'] = null;
-
-  if (node.type === 'number') {
-    literalType = 'number';
-    value = Number(node.text);
-  } else if (node.type === 'string') {
-    literalType = 'string';
-    value = node.text.replace(/^['"`]/, '').replace(/['"`]$/, '');
-  } else if (node.type === 'true') {
-    literalType = 'boolean';
-    value = true;
-  } else if (node.type === 'false') {
-    literalType = 'boolean';
-    value = false;
-  }
-
-  return {
-    ...base(node, 'Literal', _filePath),
-    value,
-    literalType,
-  };
-}
-
-function normalizeCall(node: SyntaxNode, source: string, filePath: string): CallNode {
-  const calleeNode = node.childForFieldName?.('function') ?? node.namedChildren[0] ?? node;
-  const argsNode =
-    node.childForFieldName?.('arguments') ??
-    node.namedChildren.find((child) => child.type === 'arguments');
-  const args = argsNode
-    ? argsNode.namedChildren.map((child) => normalize(child, source, filePath))
-    : [];
-
-  return {
-    ...base(node, 'Call', filePath),
-    callee: normalize(calleeNode, source, filePath),
-    args,
-    raw: source.slice(node.startIndex, node.endIndex),
-  };
-}
-
-function normalizeFunction(node: SyntaxNode, source: string, filePath: string): FunctionNode {
-  const nameNode =
-    node.childForFieldName?.('name') ??
-    node.namedChildren.find((child) => child.type === 'identifier');
-  const paramsNode =
-    node.childForFieldName?.('parameters') ??
-    node.namedChildren.find((child) => child.type === 'formal_parameters');
-  const bodyNode =
-    node.childForFieldName?.('body') ??
-    node.namedChildren.find(
-      (child) =>
-        child.type === 'statement_block' ||
-        child.type === 'expression_statement' ||
-        child.type === 'expression'
-    );
-
-  const params: ParameterNode[] = paramsNode
-    ? paramsNode.namedChildren.map((param) => ({
-        ...base(param, 'Parameter', filePath),
-        name: param.text,
-        paramType: undefined,
-      }))
-    : [];
-
-  const bodyStatements = bodyNode
-    ? bodyNode.namedChildren.map((child) => normalize(child, source, filePath))
-    : [];
-  const body: BlockNode = {
-    ...base(bodyNode ?? node, 'Block', filePath),
-    statements: bodyStatements,
-  };
-
-  return {
-    ...base(node, 'Function', filePath),
-    name: nameNode ? nameNode.text : undefined,
-    params,
-    returnType: undefined,
-    body,
-  };
-}
-
-function normalizeConditional(node: SyntaxNode, source: string, filePath: string): ConditionalNode {
-  const conditionNode = node.childForFieldName?.('condition') ?? node.namedChildren[0] ?? node;
-  const consequenceNode = node.childForFieldName?.('consequence') ?? node.namedChildren[1];
-  const alternativeNode = node.childForFieldName?.('alternative') ?? node.namedChildren[2];
-
-  const thenBlock: BlockNode = {
-    ...base(consequenceNode ?? node, 'Block', filePath),
-    statements: consequenceNode
-      ? consequenceNode.namedChildren.map((child) => normalize(child, source, filePath))
-      : [],
-  };
-
-  const elseBlock =
-    alternativeNode !== undefined
-      ? {
-          ...base(alternativeNode, 'Block', filePath),
-          statements: alternativeNode.namedChildren.map((child) =>
-            normalize(child, source, filePath)
-          ),
-        }
-      : undefined;
-
-  return {
-    ...base(node, 'Conditional', filePath),
-    condition: normalize(conditionNode, source, filePath),
-    then: thenBlock,
-    else: elseBlock,
-  };
-}
-
-function normalizeLoop(node: SyntaxNode, source: string, filePath: string): LoopNode {
-  let loopType: LoopNode['loopType'] = 'for';
-  if (node.type === 'while_statement') loopType = 'while';
-  if (node.type === 'do_statement') loopType = 'do-while';
-  if (node.type === 'for_of_statement') loopType = 'for-of';
-  if (node.type === 'for_in_statement') loopType = 'for-in';
-
-  const initNode = node.childForFieldName?.('initializer') ?? node.childForFieldName?.('left');
-  const conditionNode =
-    node.childForFieldName?.('condition') ??
-    node.childForFieldName?.('right') ??
-    node.childForFieldName?.('test');
-  const updateNode = node.childForFieldName?.('update');
-  const bodyNode =
-    node.childForFieldName?.('body') ??
-    node.namedChildren.find((child) => child.type === 'statement_block');
-
-  return {
-    ...base(node, 'Loop', filePath),
-    loopType,
-    init: initNode ? normalize(initNode, source, filePath) : undefined,
-    condition: conditionNode ? normalize(conditionNode, source, filePath) : undefined,
-    update: updateNode ? normalize(updateNode, source, filePath) : undefined,
-    body: {
-      ...base(bodyNode ?? node, 'Block', filePath),
-      statements: bodyNode
-        ? bodyNode.namedChildren.map((child) => normalize(child, source, filePath))
-        : [],
-    },
-  };
-}
-
-function normalizeReturn(node: SyntaxNode, source: string, filePath: string): ReturnNode {
-  const valueNode = node.childForFieldName?.('argument') ?? node.namedChildren[0];
-  return {
-    ...base(node, 'Return', filePath),
-    value: valueNode ? normalize(valueNode, source, filePath) : undefined,
-  };
-}
-
-function normalizeExpressionStatement(
-  node: SyntaxNode,
-  source: string,
-  filePath: string
-): ExpressionStatementNode {
-  const expressionNode = node.childForFieldName?.('expression') ?? node.namedChildren[0] ?? node;
-  return {
-    ...base(node, 'ExpressionStatement', filePath),
-    expression: normalize(expressionNode, source, filePath),
-  };
-}
-
-function normalizeVariableDeclaration(
-  node: SyntaxNode,
-  source: string,
-  filePath: string
-): VariableNode | BlockNode {
-  const kindText = node.text.trim().startsWith('const')
-    ? 'const'
-    : node.text.trim().startsWith('var')
-      ? 'var'
-      : 'let';
-
-  const declarators = node.namedChildren.filter((child) => child.type === 'variable_declarator');
-  const targets = declarators.length > 0 ? declarators : node.namedChildren;
-
-  const variables = targets.map((decl) => {
-    const nameNode =
-      decl.childForFieldName?.('name') ??
-      decl.namedChildren.find((child) => child.type === 'identifier');
-    const initNode =
-      decl.childForFieldName?.('value') ??
-      decl.childForFieldName?.('initializer') ??
-      decl.namedChildren[1];
-
-    return {
-      ...base(decl, 'Variable', filePath),
-      name: nameNode ? nameNode.text : '',
-      kind: kindText as VariableNode['kind'],
-      initializer: initNode ? normalize(initNode, source, filePath) : undefined,
-    };
-  });
-
-  if (variables.length === 1) {
-    return variables[0];
-  }
-
-  return {
-    ...base(node, 'Block', filePath),
-    statements: variables.map((variable) => {
-      const expr: ExpressionStatementNode = {
-        ...base(node, 'ExpressionStatement', filePath),
-        expression: variable,
-      };
-      return expr;
-    }),
-  };
-}
-
-function normalizeImport(node: SyntaxNode, _source: string, _filePath: string): ImportNode {
-  const importClause = node.namedChildren.find((child) => child.type === 'import_clause');
-  const moduleSpecifierNode =
-    node.childForFieldName?.('source') ??
-    node.namedChildren.find((child) => child.type === 'string');
-
-  const importedNames: string[] = [];
-
-  if (importClause) {
-    // Imported names reflect local bindings (default, namespace alias, or named/aliased imports).
-    importClause.namedChildren.forEach((child) => {
-      if (child.type === 'identifier') {
-        // Default import
-        importedNames.push(child.text);
-        return;
-      }
-
-      if (child.type === 'namespace_import') {
-        const nsAlias =
-          child.childForFieldName?.('name') ??
-          child.namedChildren.find((n) => n.type === 'identifier');
-        if (nsAlias) importedNames.push(nsAlias.text);
-        return;
-      }
-
-      if (child.type === 'named_imports') {
-        child.namedChildren
-          .filter((spec) => spec.type === 'import_specifier')
-          .forEach((spec) => {
-            const alias =
-              spec.childForFieldName?.('alias') ??
-              spec.namedChildren.find((n) => n.type === 'identifier' && n !== undefined);
-            const name =
-              spec.childForFieldName?.('name') ??
-              spec.namedChildren.find((n) => n.type === 'identifier');
-            const local = alias ?? name;
-            if (local) importedNames.push(local.text);
-          });
-      }
-    });
-  }
-
-  return {
-    ...base(node, 'Import', _filePath),
-    module: moduleSpecifierNode
-      ? moduleSpecifierNode.text.replace(/^['"`]/, '').replace(/['"`]$/, '')
-      : '',
-    imported: importedNames,
-    raw: _source.slice(node.startIndex, node.endIndex),
-  };
-}
-
-function normalizeUnknown(
-  node: SyntaxNode,
-  source: string,
-  filePath: string,
-  logger: Pick<Console, 'warn'> = console
-): UnknownNode {
-  logger.warn(
-    `[Structura Warning] Unknown Tree Sitter node type "${node.type}" encountered in file ${filePath} at line ${
-      node.startPosition.row + 1
-    }`
-  );
-
-  return {
-    id: makeDeterministicId(node, filePath),
-    type: 'Unknown',
-    raw: source.slice(node.startIndex, node.endIndex),
-    originalType: node.type,
-    location: toLocation(node),
-  };
-}
-
-function base<T extends BaseNode['type']>(
-  node: SyntaxNode,
-  type: T,
-  filePath: string
-): BaseNode & { type: T } {
-  return {
-    id: makeDeterministicId(node, filePath),
-    type,
-    location: toLocation(node),
-    originalType: node.type,
-  };
-}
-
-function toLocation(node: SyntaxNode) {
-  return {
-    startLine: node.startPosition.row,
-    startCol: node.startPosition.column,
-    endLine: node.endPosition.row,
-    endCol: node.endPosition.column,
-  };
-}
+};

--- a/core/utils/normalizers/common.ts
+++ b/core/utils/normalizers/common.ts
@@ -1,0 +1,34 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { BaseNode, NormalizedNode } from '../../types/ast';
+import { makeDeterministicId } from '../makeDeterministicId';
+
+export type NormalizeFn = (
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string
+) => NormalizedNode;
+
+export function base<T extends BaseNode['type']>(
+  node: SyntaxNode,
+  type: T,
+  filePath: string,
+  snapshotVersion: string
+): BaseNode & { type: T } {
+  return {
+    id: makeDeterministicId(node, filePath, snapshotVersion),
+    type,
+    filePath,
+    location: toLocation(node),
+    originalType: node.type,
+  };
+}
+
+export function toLocation(node: SyntaxNode) {
+  return {
+    startLine: node.startPosition.row,
+    startCol: node.startPosition.column,
+    endLine: node.endPosition.row,
+    endCol: node.endPosition.column,
+  };
+}

--- a/core/utils/normalizers/expressions.ts
+++ b/core/utils/normalizers/expressions.ts
@@ -1,0 +1,69 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { CallNode, IdentifierNode, LiteralNode } from '../../types/ast';
+import { base } from './common';
+import type { NormalizeFn } from './common';
+
+export function normalizeIdentifier(
+  node: SyntaxNode,
+  _source: string,
+  filePath: string,
+  snapshotVersion: string
+): IdentifierNode {
+  return {
+    ...base(node, 'Identifier', filePath, snapshotVersion),
+    name: node.text,
+  };
+}
+
+export function normalizeLiteral(
+  node: SyntaxNode,
+  _source: string,
+  filePath: string,
+  snapshotVersion: string
+): LiteralNode {
+  let literalType: LiteralNode['literalType'] = 'null';
+  let value: LiteralNode['value'] = null;
+
+  if (node.type === 'number') {
+    literalType = 'number';
+    value = Number(node.text);
+  } else if (node.type === 'string') {
+    literalType = 'string';
+    value = node.text.replace(/^['"`]/, '').replace(/['"`]$/, '');
+  } else if (node.type === 'true') {
+    literalType = 'boolean';
+    value = true;
+  } else if (node.type === 'false') {
+    literalType = 'boolean';
+    value = false;
+  }
+
+  return {
+    ...base(node, 'Literal', filePath, snapshotVersion),
+    value,
+    literalType,
+  };
+}
+
+export function normalizeCall(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): CallNode {
+  const calleeNode = node.childForFieldName?.('function') ?? node.namedChildren[0] ?? node;
+  const argsNode =
+    node.childForFieldName?.('arguments') ??
+    node.namedChildren.find((child) => child.type === 'arguments');
+  const args = argsNode
+    ? argsNode.namedChildren.map((child) => normalize(child, source, filePath, snapshotVersion))
+    : [];
+
+  return {
+    ...base(node, 'Call', filePath, snapshotVersion),
+    callee: normalize(calleeNode, source, filePath, snapshotVersion),
+    args,
+    raw: source.slice(node.startIndex, node.endIndex),
+  };
+}

--- a/core/utils/normalizers/functions.ts
+++ b/core/utils/normalizers/functions.ts
@@ -1,0 +1,51 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { BlockNode, FunctionNode, ParameterNode } from '../../types/ast';
+import { base } from './common';
+import type { NormalizeFn } from './common';
+
+export function normalizeFunction(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): FunctionNode {
+  const nameNode =
+    node.childForFieldName?.('name') ??
+    node.namedChildren.find((child) => child.type === 'identifier');
+  const paramsNode =
+    node.childForFieldName?.('parameters') ??
+    node.namedChildren.find((child) => child.type === 'formal_parameters');
+  const bodyNode =
+    node.childForFieldName?.('body') ??
+    node.namedChildren.find(
+      (child) =>
+        child.type === 'statement_block' ||
+        child.type === 'expression_statement' ||
+        child.type === 'expression'
+    );
+
+  const params: ParameterNode[] = paramsNode
+    ? paramsNode.namedChildren.map((param) => ({
+        ...base(param, 'Parameter', filePath, snapshotVersion),
+        name: param.text,
+        paramType: undefined,
+      }))
+    : [];
+
+  const bodyStatements = bodyNode
+    ? bodyNode.namedChildren.map((child) => normalize(child, source, filePath, snapshotVersion))
+    : [];
+  const body: BlockNode = {
+    ...base(bodyNode ?? node, 'Block', filePath, snapshotVersion),
+    statements: bodyStatements,
+  };
+
+  return {
+    ...base(node, 'Function', filePath, snapshotVersion),
+    name: nameNode ? nameNode.text : undefined,
+    params,
+    returnType: undefined,
+    body,
+  };
+}

--- a/core/utils/normalizers/imports.ts
+++ b/core/utils/normalizers/imports.ts
@@ -1,0 +1,58 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { ImportNode } from '../../types/ast';
+import { base } from './common';
+
+export function normalizeImport(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string
+): ImportNode {
+  const importClause = node.namedChildren.find((child) => child.type === 'import_clause');
+  const moduleSpecifierNode =
+    node.childForFieldName?.('source') ??
+    node.namedChildren.find((child) => child.type === 'string');
+
+  const importedNames: string[] = [];
+
+  if (importClause) {
+    importClause.namedChildren.forEach((child) => {
+      if (child.type === 'identifier') {
+        importedNames.push(child.text);
+        return;
+      }
+
+      if (child.type === 'namespace_import') {
+        const nsAlias =
+          child.childForFieldName?.('name') ??
+          child.namedChildren.find((n) => n.type === 'identifier');
+        if (nsAlias) importedNames.push(nsAlias.text);
+        return;
+      }
+
+      if (child.type === 'named_imports') {
+        child.namedChildren
+          .filter((spec) => spec.type === 'import_specifier')
+          .forEach((spec) => {
+            const alias =
+              spec.childForFieldName?.('alias') ??
+              spec.namedChildren.find((n) => n.type === 'identifier' && n !== undefined);
+            const name =
+              spec.childForFieldName?.('name') ??
+              spec.namedChildren.find((n) => n.type === 'identifier');
+            const local = alias ?? name;
+            if (local) importedNames.push(local.text);
+          });
+      }
+    });
+  }
+
+  return {
+    ...base(node, 'Import', filePath, snapshotVersion),
+    module: moduleSpecifierNode
+      ? moduleSpecifierNode.text.replace(/^['"`]/, '').replace(/['"`]$/, '')
+      : '',
+    imported: importedNames,
+    raw: source.slice(node.startIndex, node.endIndex),
+  };
+}

--- a/core/utils/normalizers/program.ts
+++ b/core/utils/normalizers/program.ts
@@ -1,0 +1,21 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { ModuleNode } from '../../types/ast';
+import { base } from './common';
+import type { NormalizeFn } from './common';
+
+export function normalizeProgram(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): ModuleNode {
+  const body = node.namedChildren.map((child) =>
+    normalize(child, source, filePath, snapshotVersion)
+  );
+  return {
+    ...base(node, 'Module', filePath, snapshotVersion),
+    path: filePath,
+    body,
+  };
+}

--- a/core/utils/normalizers/statements.ts
+++ b/core/utils/normalizers/statements.ts
@@ -1,0 +1,164 @@
+import { SyntaxNode } from 'tree-sitter';
+import type {
+  BlockNode,
+  ConditionalNode,
+  ExpressionStatementNode,
+  LoopNode,
+  ReturnNode,
+  VariableNode,
+} from '../../types/ast';
+import { base } from './common';
+import type { NormalizeFn } from './common';
+
+export function normalizeConditional(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): ConditionalNode {
+  const conditionNode = node.childForFieldName?.('condition') ?? node.namedChildren[0] ?? node;
+  const consequenceNode = node.childForFieldName?.('consequence') ?? node.namedChildren[1];
+  const alternativeNode = node.childForFieldName?.('alternative') ?? node.namedChildren[2];
+
+  const thenBlock: BlockNode = {
+    ...base(consequenceNode ?? node, 'Block', filePath, snapshotVersion),
+    statements: consequenceNode
+      ? consequenceNode.namedChildren.map((child) =>
+          normalize(child, source, filePath, snapshotVersion)
+        )
+      : [],
+  };
+
+  const elseBlock =
+    alternativeNode !== undefined
+      ? {
+          ...base(alternativeNode, 'Block', filePath, snapshotVersion),
+          statements: alternativeNode.namedChildren.map((child) =>
+            normalize(child, source, filePath, snapshotVersion)
+          ),
+        }
+      : undefined;
+
+  return {
+    ...base(node, 'Conditional', filePath, snapshotVersion),
+    condition: normalize(conditionNode, source, filePath, snapshotVersion),
+    then: thenBlock,
+    else: elseBlock,
+  };
+}
+
+export function normalizeLoop(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): LoopNode {
+  let loopType: LoopNode['loopType'] = 'for';
+  if (node.type === 'while_statement') loopType = 'while';
+  if (node.type === 'do_statement') loopType = 'do-while';
+  if (node.type === 'for_of_statement') loopType = 'for-of';
+  if (node.type === 'for_in_statement') loopType = 'for-in';
+
+  const initNode = node.childForFieldName?.('initializer') ?? node.childForFieldName?.('left');
+  const conditionNode =
+    node.childForFieldName?.('condition') ??
+    node.childForFieldName?.('right') ??
+    node.childForFieldName?.('test');
+  const updateNode = node.childForFieldName?.('update');
+  const bodyNode =
+    node.childForFieldName?.('body') ??
+    node.namedChildren.find((child) => child.type === 'statement_block');
+
+  return {
+    ...base(node, 'Loop', filePath, snapshotVersion),
+    loopType,
+    init: initNode ? normalize(initNode, source, filePath, snapshotVersion) : undefined,
+    condition: conditionNode ? normalize(conditionNode, source, filePath, snapshotVersion) : undefined,
+    update: updateNode ? normalize(updateNode, source, filePath, snapshotVersion) : undefined,
+    body: {
+      ...base(bodyNode ?? node, 'Block', filePath, snapshotVersion),
+      statements: bodyNode
+        ? bodyNode.namedChildren.map((child) => normalize(child, source, filePath, snapshotVersion))
+        : [],
+    },
+  };
+}
+
+export function normalizeReturn(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): ReturnNode {
+  const valueNode = node.childForFieldName?.('argument') ?? node.namedChildren[0];
+  return {
+    ...base(node, 'Return', filePath, snapshotVersion),
+    value: valueNode ? normalize(valueNode, source, filePath, snapshotVersion) : undefined,
+  };
+}
+
+export function normalizeExpressionStatement(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): ExpressionStatementNode {
+  const expressionNode = node.childForFieldName?.('expression') ?? node.namedChildren[0] ?? node;
+  return {
+    ...base(node, 'ExpressionStatement', filePath, snapshotVersion),
+    expression: normalize(expressionNode, source, filePath, snapshotVersion),
+  };
+}
+
+export function normalizeVariableDeclaration(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  normalize: NormalizeFn
+): VariableNode | BlockNode {
+  const kindText = node.text.trim().startsWith('const')
+    ? 'const'
+    : node.text.trim().startsWith('var')
+      ? 'var'
+      : 'let';
+
+  const declarators = node.namedChildren.filter((child) => child.type === 'variable_declarator');
+  const targets = declarators.length > 0 ? declarators : node.namedChildren;
+
+  const variables = targets.map((decl) => {
+    const nameNode =
+      decl.childForFieldName?.('name') ??
+      decl.namedChildren.find((child) => child.type === 'identifier');
+    const initNode =
+      decl.childForFieldName?.('value') ??
+      decl.childForFieldName?.('initializer') ??
+      decl.namedChildren[1];
+
+    return {
+      ...base(decl, 'Variable', filePath, snapshotVersion),
+      name: nameNode ? nameNode.text : '',
+      kind: kindText as VariableNode['kind'],
+      initializer: initNode ? normalize(initNode, source, filePath, snapshotVersion) : undefined,
+    };
+  });
+
+  if (variables.length === 1) {
+    return variables[0];
+  }
+
+  return {
+    ...base(node, 'Block', filePath, snapshotVersion),
+    statements: variables.map((variable) => {
+      const expr: ExpressionStatementNode = {
+        ...base(node, 'ExpressionStatement', filePath, snapshotVersion),
+        expression: variable,
+      };
+      return expr;
+    }),
+  };
+}

--- a/core/utils/normalizers/unknown.ts
+++ b/core/utils/normalizers/unknown.ts
@@ -1,0 +1,22 @@
+import { SyntaxNode } from 'tree-sitter';
+import type { UnknownNode } from '../../types/ast';
+import { base } from './common';
+
+export function normalizeUnknown(
+  node: SyntaxNode,
+  source: string,
+  filePath: string,
+  snapshotVersion: string,
+  logger: Pick<Console, 'warn'> = console
+): UnknownNode {
+  logger.warn(
+    `[Structura Warning] Unknown Tree Sitter node type "${node.type}" encountered in file ${filePath} at line ${
+      node.startPosition.row + 1
+    }`
+  );
+
+  return {
+    ...base(node, 'Unknown', filePath, snapshotVersion),
+    raw: source.slice(node.startIndex, node.endIndex),
+  };
+}

--- a/docs/docs/ast-system/snapshot-versioning.md
+++ b/docs/docs/ast-system/snapshot-versioning.md
@@ -1,0 +1,41 @@
+# Snapshot versioning and deterministic IDs
+
+Structura captures code snapshots (parsed sources, normalized ASTs, and derived graphs) so analysis can be repeated, compared, and evolved safely. Every normalized AST node gets a deterministic, hash-based `id` that is scoped by a manually managed `SNAPSHOT_VERSION`.
+
+## What snapshot version means
+
+- Represents the semantics of the normalized AST schema and extraction rules (how we parse, normalize, and interpret nodes and edges).
+- **Not** tied to time, git commits, or runtime state.
+- Included in `makeDeterministicId` so the same source + file path yields different ids when semantics change.
+
+## Why it matters
+
+- **Persistence:** Stored ASTs and graphs rely on stable ids to join data across runs.
+- **Graph edges:** Import/call/dependency edges reference node ids; changing semantics without a version bump corrupts relationships.
+- **Evolution analysis:** Comparing snapshots over time depends on ids being stable for unchanged semantics and intentionally different when semantics shift.
+
+## When to bump `SNAPSHOT_VERSION`
+
+Bump the version when semantics change, including:
+
+- AST normalization shape or interpretation changes (e.g., new node kinds, different child assignment, location rules).
+- Identity generation inputs change (hash key fields, file path handling, snapshot scoping).
+- Extraction logic that affects graph construction (e.g., import/require detection, edge creation rules).
+- Any change that would alter persisted AST/graph meaning even if the code text is identical.
+
+## When **not** to bump
+
+Do **not** bump for:
+
+- Pure refactors (no shape/meaning change).
+- Performance optimizations.
+- Formatting, logging, or comments.
+- Internal code moves that preserve observable normalization/extraction behavior.
+
+## How it’s used
+
+- `SNAPSHOT_VERSION` lives in `core/config/snapshotVersion.ts`.
+- `normalize` threads the version into `makeDeterministicId`, scoping every node id in a run.
+- Snapshot creation and downstream analyses must pass the same version for all files in a run.
+
+Keep the version stable across runs until you intentionally change semantics; bump it exactly when those semantics shift to avoid silent corruption and to make evolution analysis trustworthy.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
         'ast-system/ast-extraction-pipeline',
         'ast-system/normalization-overview',
         'ast-system/normalized-ast-schema',
+        'ast-system/snapshot-versioning',
         'ast-system/examples',
       ],
     },

--- a/scripts/collect-imports.ts
+++ b/scripts/collect-imports.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { crawlJsFiles } from '../ingestion/crawler';
 import { parseJSFile } from '../ingestion/parser/js/parseFile';
 import { normalize } from '../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../core/config/snapshotVersion';
 import type { ModuleNode, NormalizedNode } from '../core/types/ast';
 import { extractImportsFromModule } from '../core/imports/extractor';
 
@@ -21,7 +22,12 @@ async function parseAndNormalize(filePath: string): Promise<ModuleNode | null> {
   }
 
   const source = fs.readFileSync(filePath, 'utf8');
-  const root: NormalizedNode = normalize(parseResult.tree.rootNode, source, filePath);
+  const root: NormalizedNode = normalize(
+    parseResult.tree.rootNode,
+    source,
+    filePath,
+    SNAPSHOT_VERSION
+  );
   if (root.type !== 'Module') {
     console.warn(`Skipping ${filePath}: expected Module root, got ${root.type}`);
     return null;

--- a/scripts/resolveImports.ts
+++ b/scripts/resolveImports.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { crawlJsFiles } from '../ingestion/crawler';
 import { parseJSFile } from '../ingestion/parser/js/parseFile';
 import { normalize } from '../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../core/config/snapshotVersion';
 import type { ModuleNode, NormalizedNode } from '../core/types/ast';
 import { extractImportsFromModule } from '../core/imports/extractor';
 import { resolveImport, ImportResolution } from '../core/imports/import-resolver';
@@ -80,7 +81,12 @@ async function parseAndNormalize(filePath: string): Promise<ModuleNode | null> {
     return null;
   }
   const source = fs.readFileSync(filePath, 'utf8');
-  const root: NormalizedNode = normalize(parseResult.tree.rootNode, source, filePath);
+  const root: NormalizedNode = normalize(
+    parseResult.tree.rootNode,
+    source,
+    filePath,
+    SNAPSHOT_VERSION
+  );
   if (root.type !== 'Module') {
     console.warn(`Skipping ${filePath}: expected Module root, got ${root.type}`);
     return null;

--- a/tests/imports/extractor.test.ts
+++ b/tests/imports/extractor.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { extractImportsFromModule } from '../../core/imports/extractor';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 import type { ModuleNode, NormalizedNode } from '../../core/types/ast';
 import { parseJSFile } from '../../ingestion/parser/js/parseFile';
 
@@ -13,7 +14,12 @@ async function parseAndNormalizeModule(source: string, ext = '.js'): Promise<Mod
   fs.writeFileSync(filePath, source, 'utf8');
   const parseResult = await parseJSFile(filePath);
   if (!parseResult.tree) throw new Error('Parse failed');
-  const root: NormalizedNode = normalize(parseResult.tree.rootNode, source, filePath);
+  const root: NormalizedNode = normalize(
+    parseResult.tree.rootNode,
+    source,
+    filePath,
+    SNAPSHOT_VERSION
+  );
   fs.rmSync(tmpDir, { recursive: true, force: true });
   if (root.type !== 'Module') throw new Error('Expected Module root');
   return root;

--- a/tests/normalization/call.test.ts
+++ b/tests/normalization/call.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('call normalization', () => {
   it('normalizes call expressions and keeps ids deterministic', () => {
@@ -19,8 +20,8 @@ describe('call normalization', () => {
       throw new Error('Call expression not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Call' || second.type !== 'Call') {
       throw new Error('Expected call normalization output');

--- a/tests/normalization/conditional.test.ts
+++ b/tests/normalization/conditional.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('conditional normalization', () => {
   it('normalizes if/else statements and keeps ids deterministic', () => {
@@ -20,8 +21,8 @@ describe('conditional normalization', () => {
       throw new Error('If statement not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Conditional' || second.type !== 'Conditional') {
       throw new Error('Expected conditional normalization output');

--- a/tests/normalization/deterministic-id.test.ts
+++ b/tests/normalization/deterministic-id.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import Parser from 'tree-sitter';
+import JavaScript from 'tree-sitter-javascript';
+import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
+import type { NormalizedNode, ModuleNode } from '../../core/types/ast';
+
+// Narrow any normalized root into a Module node; throws if parser returns something unexpected.
+function toModule(node: NormalizedNode): ModuleNode {
+  if (node.type !== 'Module') {
+    throw new Error(`Expected Module root, got ${node.type}`);
+  }
+  return node as ModuleNode;
+}
+
+// Depth-first walk to collect every node id in document order.
+function collectIds(node: NormalizedNode, acc: string[] = []): string[] {
+  acc.push(node.id);
+  switch (node.type) {
+    case 'Module':
+      node.body.forEach((child) => collectIds(child, acc));
+      break;
+    case 'Block':
+      node.statements.forEach((stmt) => collectIds(stmt, acc));
+      break;
+    case 'ExpressionStatement':
+      collectIds(node.expression, acc);
+      break;
+    case 'Function':
+      collectIds(node.body, acc);
+      node.params.forEach((p) => acc.push(p.id));
+      break;
+    case 'Call':
+      collectIds(node.callee, acc);
+      node.args.forEach((arg) => collectIds(arg, acc));
+      break;
+    case 'Variable':
+      if (node.initializer) collectIds(node.initializer, acc);
+      break;
+    case 'Return':
+      if (node.value) collectIds(node.value, acc);
+      break;
+    case 'Conditional':
+      collectIds(node.condition, acc);
+      collectIds(node.then, acc);
+      if (node.else) collectIds(node.else, acc);
+      break;
+    case 'Loop':
+      if (node.init) collectIds(node.init, acc);
+      if (node.condition) collectIds(node.condition, acc);
+      if (node.update) collectIds(node.update, acc);
+      collectIds(node.body, acc);
+      break;
+    default:
+      break;
+  }
+  return acc;
+}
+
+describe('deterministic normalization ids', () => {
+  it('produces stable ids for the same source and file path, and different ids when file path changes', () => {
+    const parser = new Parser();
+    parser.setLanguage(JavaScript as any);
+
+    // Simple sample program to exercise multiple node kinds.
+    const source = [
+      `import fs from 'fs';`,
+      `const x = 1;`,
+      `function echo(v) {`,
+      `  return v;`,
+      `}`,
+      `echo(x);`,
+    ].join('\n');
+
+    // Parse the same source three times; two share a path/version, one uses a different path, and later we also vary version.
+    const treeA1 = parser.parse(source);
+    const treeA2 = parser.parse(source);
+    const treeB = parser.parse(source);
+
+    const modA1 = toModule(
+      normalize(treeA1.rootNode, source, '/tmp/fileA.js', SNAPSHOT_VERSION)
+    );
+    const modA2 = toModule(
+      normalize(treeA2.rootNode, source, '/tmp/fileA.js', SNAPSHOT_VERSION)
+    );
+    const modB = toModule(
+      normalize(treeB.rootNode, source, '/tmp/fileB.js', SNAPSHOT_VERSION)
+    );
+    const modAVersion2 = toModule(
+      normalize(treeA1.rootNode, source, '/tmp/fileA.js', 'v2')
+    );
+
+    // Collect all ids to assert whole-tree stability, not just the root.
+    const idsA1 = collectIds(modA1);
+    const idsA2 = collectIds(modA2);
+    const idsB = collectIds(modB);
+    const idsAVersion2 = collectIds(modAVersion2);
+
+    // Same source + same filePath => identical ids.
+    expect(idsA1.length).toBeGreaterThan(0);
+    expect(idsA1).toEqual(idsA2);
+
+    // Same source + different filePath => ids diverge (filePath participates in identity).
+    expect(idsB.length).toBe(idsA1.length);
+    expect(idsB).not.toEqual(idsA1);
+    expect(modB.id).not.toBe(modA1.id);
+
+    // Same source + same filePath but different snapshotVersion => ids diverge.
+    expect(idsAVersion2.length).toBe(idsA1.length);
+    expect(idsAVersion2).not.toEqual(idsA1);
+    expect(modAVersion2.id).not.toBe(modA1.id);
+  });
+});

--- a/tests/normalization/function.test.ts
+++ b/tests/normalization/function.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('function normalization', () => {
   it('normalizes functions with parameters, bodies, and deterministic ids', () => {
@@ -21,8 +22,8 @@ describe('function normalization', () => {
       throw new Error('Function declaration not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Function' || second.type !== 'Function') {
       throw new Error('Expected function normalization output');

--- a/tests/normalization/identifier.test.ts
+++ b/tests/normalization/identifier.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('identifier normalization', () => {
   it('normalizes identifiers and keeps ids deterministic', () => {
@@ -16,8 +17,8 @@ describe('identifier normalization', () => {
       throw new Error('Identifier node not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Identifier' || second.type !== 'Identifier') {
       throw new Error('Expected identifier normalization output');

--- a/tests/normalization/import.test.ts
+++ b/tests/normalization/import.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 function normalizeFirstImport(source: string) {
   const parser = new Parser();
@@ -9,7 +10,7 @@ function normalizeFirstImport(source: string) {
   const tree = parser.parse(source);
   const importNode = tree.rootNode.namedChildren.find((child) => child.type === 'import_statement');
   if (!importNode) throw new Error('Import node not found');
-  const normalized = normalize(importNode, source, 'test.js');
+  const normalized = normalize(importNode, source, 'test.js', SNAPSHOT_VERSION);
   if (normalized.type !== 'Import') throw new Error('Expected Import node');
   return normalized;
 }

--- a/tests/normalization/literal.test.ts
+++ b/tests/normalization/literal.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('literal normalization', () => {
   it('normalizes string literals and keeps ids deterministic', () => {
@@ -16,8 +17,8 @@ describe('literal normalization', () => {
       throw new Error('Literal node not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Literal' || second.type !== 'Literal') {
       throw new Error('Expected literal normalization output');

--- a/tests/normalization/loop.test.ts
+++ b/tests/normalization/loop.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('loop normalization', () => {
   it('normalizes while loops and keeps ids deterministic', () => {
@@ -16,8 +17,8 @@ describe('loop normalization', () => {
       throw new Error('While statement not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Loop' || second.type !== 'Loop') {
       throw new Error('Expected loop normalization output');

--- a/tests/normalization/unknown.test.ts
+++ b/tests/normalization/unknown.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('unknown node normalization', () => {
   it('wraps unsupported nodes in UnknownNode with deterministic ids', () => {
@@ -16,8 +17,8 @@ describe('unknown node normalization', () => {
       throw new Error('Class declaration not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Unknown' || second.type !== 'Unknown') {
       throw new Error('Expected unknown normalization output');

--- a/tests/normalization/variable.test.ts
+++ b/tests/normalization/variable.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import Parser from 'tree-sitter';
 import JavaScript from 'tree-sitter-javascript';
 import { normalize } from '../../core/utils/normalize';
+import { SNAPSHOT_VERSION } from '../../core/config/snapshotVersion';
 
 describe('variable normalization', () => {
   it('normalizes variable declarations and keeps ids deterministic', () => {
@@ -16,8 +17,8 @@ describe('variable normalization', () => {
       throw new Error('Variable declaration not found in parsed tree');
     }
 
-    const first = normalize(node, source, 'test.js');
-    const second = normalize(node, source, 'test.js');
+    const first = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
+    const second = normalize(node, source, 'test.js', SNAPSHOT_VERSION);
 
     if (first.type !== 'Variable' || second.type !== 'Variable') {
       throw new Error('Expected variable normalization output');


### PR DESCRIPTION
- Add common utilities for normalizing AST nodes including `base` and `toLocation`.
- Implement normalization functions for identifiers, literals, function declarations, imports, and various statement types (conditional, loop, return, expression statement, variable declaration).
- Introduce handling for unknown node types with appropriate logging.
- Establish snapshot versioning for deterministic ID generation in normalized AST nodes.
- Update documentation to clarify snapshot versioning and its significance in AST normalization.
- Enhance tests to ensure deterministic IDs and correct normalization behavior across various node types.