### PR TITLE
STR-78: snapshot model and new migrations

### DIFF
--- a/backend/prisma/migrations/20251218182007_init_snapshot/migration.sql
+++ b/backend/prisma/migrations/20251218182007_init_snapshot/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `childIds` on the `AstNode` table. All the data in the column will be lost.
+  - Added the required column `snapshotId` to the `AstNode` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "AstNode" DROP COLUMN "childIds",
+ADD COLUMN     "snapshotId" UUID NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Snapshot" (
+    "id" UUID NOT NULL,
+    "snapshotVersion" TEXT NOT NULL,
+    "rootPath" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Snapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Snapshot_snapshotVersion_idx" ON "Snapshot"("snapshotVersion");
+
+-- AddForeignKey
+ALTER TABLE "AstNode" ADD CONSTRAINT "AstNode_snapshotId_fkey" FOREIGN KEY ("snapshotId") REFERENCES "Snapshot"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,7 +13,6 @@ model User {
   name  String?
 }
 
-
 model AstNode {
   id            String   @id @db.Uuid
   filePath      String
@@ -23,7 +22,8 @@ model AstNode {
   parent        AstNode? @relation("AstNodeToParent", fields: [parentId], references: [id], onDelete: Cascade)
   children      AstNode[] @relation("AstNodeToParent")
 
-  childIds      String[] @db.Uuid
+  snapshotId    String   @db.Uuid
+  snapshot      Snapshot @relation(fields: [snapshotId], references: [id], onDelete: Cascade)
 
   data          Json
   location      Json?
@@ -35,4 +35,15 @@ model AstNode {
   @@index([type])
   @@index([filePath])
   @@index([parentId])
+}
+
+model Snapshot {
+  id              String   @id @default(uuid()) @db.Uuid
+  snapshotVersion String
+  rootPath        String
+  createdAt       DateTime @default(now())
+
+  astNodes AstNode[]
+
+  @@index([snapshotVersion])
 }


### PR DESCRIPTION
- Created a new snapshot model to represent a snapshot which is defined by a snapshot version (represents analysis semantics version), created at (the time snapshot was created) and rootPath.
- Migrated the db with the new schema to generate new migration files.